### PR TITLE
Make gazebo macro for abb_irb1200 contain only gazebo specific tags

### DIFF
--- a/abb_irb1200_gazebo/urdf/irb1200_5_90.xacro
+++ b/abb_irb1200_gazebo/urdf/irb1200_5_90.xacro
@@ -2,13 +2,27 @@
 
 <robot name="abb_irb1200_5_90" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find abb_irb1200_gazebo)/urdf/irb1200_5_90_macro.xacro" />
+  <xacro:include filename="$(find abb_irb1200_description)/urdf/irb1200_5_90_macro.xacro" />
 
-  <xacro:abb_irb1200_5_90_g prefix="" />
+  <!-- get base ABB IRB1200 model -->
+  <xacro:abb_irb1200_5_90 prefix="${prefix}" />
+
+  <!-- get gazebo add-ons -->
+  <xacro:abb_irb1200_5_90_gazebo_spec prefix="${prefix}" />
+
   <!-- connect robot with world -->
   <link name="world" />
   <joint name="world_to_base_link_joint" type="fixed">
     <parent link="world" />
     <child link="base_link" />
   </joint>
+
+  <!-- ros_control plugin -->
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+      <robotNamespace>/</robotNamespace>
+      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+    </plugin>
+  </gazebo>
 
 </robot>

--- a/abb_irb1200_gazebo/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_gazebo/urdf/irb1200_5_90_macro.xacro
@@ -1,105 +1,93 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-<xacro:include filename="$(find abb_irb1200_support)/urdf/irb1200_5_90_macro.xacro"/>
-<xacro:macro name="abb_irb1200_5_90_g" params="prefix">
+  <xacro:macro name="abb_irb1200_5_90_gazebo_spec" params="prefix">
 
-  <!-- get base ABB IRB1200 model -->
-  <xacro:abb_irb1200_5_90 prefix="${prefix}" />
+    <!-- transmission list -->
+    <transmission name="${prefix}tran1">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_1">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor1">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran2">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_2">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor2">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran3">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_3">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor3">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran4">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_4">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor4">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran5">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_5">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor5">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <transmission name="${prefix}tran6">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_6">
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}motor6">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+    <!-- end of transmission list -->
 
-  <!-- transmission list -->
-  <transmission name="${prefix}tran1">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="${prefix}joint_1">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="${prefix}motor1">
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-  <transmission name="${prefix}tran2">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="${prefix}joint_2">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="${prefix}motor2">
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-  <transmission name="${prefix}tran3">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="${prefix}joint_3">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="${prefix}motor3">
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-  <transmission name="${prefix}tran4">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="${prefix}joint_4">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="${prefix}motor4">
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-  <transmission name="${prefix}tran5">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="${prefix}joint_5">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="${prefix}motor5">
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-  <transmission name="${prefix}tran6">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="${prefix}joint_6">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="${prefix}motor6">
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-  <!-- end of transmission list -->
-
-  <!-- Gazebo-specific link properties -->
-  <gazebo reference="${prefix}base_link">
-    <material>Gazebo/Orange</material>
-    <turnGravityOff>true</turnGravityOff>
-  </gazebo>
-  <gazebo reference="${prefix}link_1">
-    <material>Gazebo/Orange</material>
-    <turnGravityOff>true</turnGravityOff>
-  </gazebo>
-  <gazebo reference="${prefix}link_2">
-    <material>Gazebo/Orange</material>
-    <turnGravityOff>true</turnGravityOff>
-  </gazebo>
-  <gazebo reference="${prefix}link_3">
-    <material>Gazebo/Orange</material>
-    <turnGravityOff>true</turnGravityOff>
-  </gazebo>
-  <gazebo reference="${prefix}link_4">
-    <material>Gazebo/Orange</material>
-    <turnGravityOff>true</turnGravityOff>
-  </gazebo>
-  <gazebo reference="${prefix}link_5">
-    <material>Gazebo/Orange</material>
-    <turnGravityOff>true</turnGravityOff>
-  </gazebo>
-  <gazebo reference="${prefix}link_6">
-    <material>Gazebo/Black</material>
-    <turnGravityOff>true</turnGravityOff>
-  </gazebo>
-
-  <!-- ros_control plugin -->
-  <gazebo>
-    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-      <robotNamespace>/</robotNamespace>
-      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
-    </plugin>
-  </gazebo>
+    <!-- Gazebo-specific link properties -->
+    <gazebo reference="${prefix}base_link">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_1">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_2">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_3">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_4">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_5">
+      <material>Gazebo/Orange</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
+    <gazebo reference="${prefix}link_6">
+      <material>Gazebo/Black</material>
+      <turnGravityOff>true</turnGravityOff>
+    </gazebo>
 
   </xacro:macro>
 </robot>


### PR DESCRIPTION
Makes the abb_irb1200 5/0.9 gazebo URDF contain only gazebo specific tags so that it can be easily combined with other URDFs.